### PR TITLE
首页卡片三网一行改三行直显

### DIFF
--- a/AICACHE.md
+++ b/AICACHE.md
@@ -23,6 +23,7 @@
 - 版本：0.6.6 → 0.6.7。
 - 0.6.8：纯升版号（代码无变化，把去重+实心条两次改动正式落版，之前漏升版是我的错）。
 - 0.6.9：三网每行加丢包历史第二排（lossBars，走自带getLossToneClass），对齐图二每家两排。临时夹具强制legacy验证两排渲染后已恢复夹具，截图为证；lint+build过，已提交推送。
+- 0.6.10：回退第二排（metric下无真实分任务丢包历史，灰条是噪音，不如6.8），回到每行名字+延迟+丢包数字+延迟历史一排。数据层loss标量保留。
 - 去重：分任务迷你条并入自带唯一的`toLatencyHistoryBar`构造，与聚合大块同一套色阶/tooltip，不再两套并存。lint+build通过，包不变`ink-build-b4ea02a.zip`。
 - 真机验证（visual lab代替）：一次性`threeline.verify.spec.ts`（已删）+ `pingTaskOrdering`夹具（浙江移动/联通/电信3任务）跑通，首页卡三行名字+延迟+丢包+各自行实心历史条均渲染，顺序跟后端一致；截图`test-results/threeline-verify.png`保留。
 - 本机真实部署验证：Komari 1.4.3 dashboard（127.0.0.1:25774）+ agent（本地验证机，在线）+ ink 0.6.7（`ink-build-b4ea02a.zip`已导入并设为当前主题）；直插3条TCP ping任务（河南电信180.76.76.76:80 / 河南联通119.29.29.29:80 / 河南移动223.5.5.5:443，10s间隔），agent真实上报，`test-results/real-deploy-card.png`为证：三行名字+延迟（44/48/46ms）+丢包0.0%+各自行历史条，下面平均大块不动。

--- a/AICACHE.md
+++ b/AICACHE.md
@@ -13,6 +13,26 @@
 
 ## 当前任务
 
+- 状态：in_progress，用户需求第二轮：三网三行每行还要有自己的历史条+丢包（M4 UI/UX）
+- 目标：接上一版三行名字+延迟，补上分任务丢包标量和分任务延迟历史迷你条，对齐junimo直观度，不写死地区、不伪造分任务丢包历史（metric丢包明细聚合，只给标量）。
+- 改动：
+  1. `useNodePingStats.ts`：`NodePingTaskLatency`加`loss`+`history`；metric路径按`normalizeTaskId`过滤该任务采样单独分桶；legacy路径按`taskRecords`分组单独分桶；`CACHE_VERSION 9→10`。
+  2. `useNodePingDisplay.ts`：`NodePingTaskLatencyItem`加`lossText/lossTooltip/historyBars`，复用`getLatencyToneClass`+时间tooltip。
+  3. `NodeCard.vue`三网块：每行`任务名 + 延迟 + 丢包`首行，下挂`h-1`历史条grid；大数据块延迟/丢包不动。
+- 验证：lint三文件零告警；`bun run build`通过，`ink-build-b4ea02a.zip (3.58MB)`，0.6.7。沙盒无真实后端，分任务条待真机看。
+- 版本：0.6.6 → 0.6.7。
+- 去重：分任务迷你条并入自带唯一的`toLatencyHistoryBar`构造，与聚合大块同一套色阶/tooltip，不再两套并存。lint+build通过，包不变`ink-build-b4ea02a.zip`。
+- 真机验证（visual lab代替）：一次性`threeline.verify.spec.ts`（已删）+ `pingTaskOrdering`夹具（浙江移动/联通/电信3任务）跑通，首页卡三行名字+延迟+丢包+各自行实心历史条均渲染，顺序跟后端一致；截图`test-results/threeline-verify.png`保留。
+- 本机真实部署验证：Komari 1.4.3 dashboard（127.0.0.1:25774）+ agent（本地验证机，在线）+ ink 0.6.7（`ink-build-b4ea02a.zip`已导入并设为当前主题）；直插3条TCP ping任务（河南电信180.76.76.76:80 / 河南联通119.29.29.29:80 / 河南移动223.5.5.5:443，10s间隔），agent真实上报，`test-results/real-deploy-card.png`为证：三行名字+延迟（44/48/46ms）+丢包0.0%+各自行历史条，下面平均大块不动。
+- 目标：把`NodeCard.vue`三网行从`170ms·203ms·185ms`单行`·`分隔，改成按后台实际任务名纵向一任务一行，最多3行，不写死江苏字样。数据层`taskLatencies`本来就是分任务不平均、保后台顺序，直接复用。
+- 改动：
+  1. `src/composables/useNodePingDisplay.ts`：`NodePingTaskLatencyItem`新增`name`字段并透出。
+  2. `src/components/NodeCard.vue`三网块改`flex-col`纵向`v-for`，每行任务名+延迟值+Tooltip，保留离线模糊、无数据不占位。
+- 验证：`bun run lint`两文件零告警通过；`bun run build`通过，产出`ink-build-b4ea02a.zip (3.57MB)`，zip含`komari-theme.json`+`preview.png`+`dist/`，版本0.6.6。沙盒无真实Komari后端，三行效果待真机验证。
+- 版本：`komari-theme.json` 0.6.5 → 0.6.6 并重打 zip。
+
+## 上一轮任务（done）
+
 - 状态：done，用户反馈两处 bug 修复：顶部“实时速率”卡片上传单位硬编码 + 离线节点卡片圆角与卡片本体不一致
 - 目标：核实并修复用户反馈的两个具体问题：
   1. **“上传速率单位有问题，MB/s 也显示 KB/s”**：`NodeGeneralCards.vue` 的 `netSpeed`（首页“实时速率”卡片）case 里，`unit` 字段把上传速率单位写成了固定字符串 `` `KB/s · ↓${...}` ``，而下载那一半正确地用了 `formattedSpeedDown.value.unit`（随数值动态换算 KB/s、MB/s、GB/s）。也就是上传速率一旦跨过 1024 KB/s 换算成 MB/s，数值变了但单位显示仍卡在 "KB/s"。改成读取 `formattedSpeedUp.value.unit`，和下载保持同样的动态换算逻辑。`formattedSpeedUp`/`formattedSpeedDown` 本身（`formatBytesPerSecondSplit`）没有问题，只是这一处展示层把值硬编码了。

--- a/AICACHE.md
+++ b/AICACHE.md
@@ -22,6 +22,7 @@
 - 验证：lint三文件零告警；`bun run build`通过，`ink-build-b4ea02a.zip (3.58MB)`，0.6.7。沙盒无真实后端，分任务条待真机看。
 - 版本：0.6.6 → 0.6.7。
 - 0.6.8：纯升版号（代码无变化，把去重+实心条两次改动正式落版，之前漏升版是我的错）。
+- 0.6.9：三网每行加丢包历史第二排（lossBars，走自带getLossToneClass），对齐图二每家两排。临时夹具强制legacy验证两排渲染后已恢复夹具，截图为证；lint+build过，已提交推送。
 - 去重：分任务迷你条并入自带唯一的`toLatencyHistoryBar`构造，与聚合大块同一套色阶/tooltip，不再两套并存。lint+build通过，包不变`ink-build-b4ea02a.zip`。
 - 真机验证（visual lab代替）：一次性`threeline.verify.spec.ts`（已删）+ `pingTaskOrdering`夹具（浙江移动/联通/电信3任务）跑通，首页卡三行名字+延迟+丢包+各自行实心历史条均渲染，顺序跟后端一致；截图`test-results/threeline-verify.png`保留。
 - 本机真实部署验证：Komari 1.4.3 dashboard（127.0.0.1:25774）+ agent（本地验证机，在线）+ ink 0.6.7（`ink-build-b4ea02a.zip`已导入并设为当前主题）；直插3条TCP ping任务（河南电信180.76.76.76:80 / 河南联通119.29.29.29:80 / 河南移动223.5.5.5:443，10s间隔），agent真实上报，`test-results/real-deploy-card.png`为证：三行名字+延迟（44/48/46ms）+丢包0.0%+各自行历史条，下面平均大块不动。

--- a/AICACHE.md
+++ b/AICACHE.md
@@ -21,6 +21,7 @@
   3. `NodeCard.vue`三网块：每行`任务名 + 延迟 + 丢包`首行，下挂`h-1`历史条grid；大数据块延迟/丢包不动。
 - 验证：lint三文件零告警；`bun run build`通过，`ink-build-b4ea02a.zip (3.58MB)`，0.6.7。沙盒无真实后端，分任务条待真机看。
 - 版本：0.6.6 → 0.6.7。
+- 0.6.8：纯升版号（代码无变化，把去重+实心条两次改动正式落版，之前漏升版是我的错）。
 - 去重：分任务迷你条并入自带唯一的`toLatencyHistoryBar`构造，与聚合大块同一套色阶/tooltip，不再两套并存。lint+build通过，包不变`ink-build-b4ea02a.zip`。
 - 真机验证（visual lab代替）：一次性`threeline.verify.spec.ts`（已删）+ `pingTaskOrdering`夹具（浙江移动/联通/电信3任务）跑通，首页卡三行名字+延迟+丢包+各自行实心历史条均渲染，顺序跟后端一致；截图`test-results/threeline-verify.png`保留。
 - 本机真实部署验证：Komari 1.4.3 dashboard（127.0.0.1:25774）+ agent（本地验证机，在线）+ ink 0.6.7（`ink-build-b4ea02a.zip`已导入并设为当前主题）；直插3条TCP ping任务（河南电信180.76.76.76:80 / 河南联通119.29.29.29:80 / 河南移动223.5.5.5:443，10s间隔），agent真实上报，`test-results/real-deploy-card.png`为证：三行名字+延迟（44/48/46ms）+丢包0.0%+各自行历史条，下面平均大块不动。

--- a/komari-theme.json
+++ b/komari-theme.json
@@ -2,7 +2,7 @@
   "name": "ink",
   "short": "ink",
   "description": "A minimal ink theme for Komari (deep navy-black, shadcn-inspired)",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "author": "jacob-bytes",
   "url": "https://github.com/jacob-bytes/komari-theme-ink",
   "preview": "preview.png",

--- a/komari-theme.json
+++ b/komari-theme.json
@@ -2,7 +2,7 @@
   "name": "ink",
   "short": "ink",
   "description": "A minimal ink theme for Komari (deep navy-black, shadcn-inspired)",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "author": "jacob-bytes",
   "url": "https://github.com/jacob-bytes/komari-theme-ink",
   "preview": "preview.png",

--- a/komari-theme.json
+++ b/komari-theme.json
@@ -2,7 +2,7 @@
   "name": "ink",
   "short": "ink",
   "description": "A minimal ink theme for Komari (deep navy-black, shadcn-inspired)",
-  "version": "0.6.5",
+  "version": "0.6.7",
   "author": "jacob-bytes",
   "url": "https://github.com/jacob-bytes/komari-theme-ink",
   "preview": "preview.png",

--- a/komari-theme.json
+++ b/komari-theme.json
@@ -2,7 +2,7 @@
   "name": "ink",
   "short": "ink",
   "description": "A minimal ink theme for Komari (deep navy-black, shadcn-inspired)",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": "jacob-bytes",
   "url": "https://github.com/jacob-bytes/komari-theme-ink",
   "preview": "preview.png",

--- a/src/components/NodeCard.vue
+++ b/src/components/NodeCard.vue
@@ -504,6 +504,27 @@ const customTags = computed(() => parseTags(props.node.tags).flatMap(t => t.text
                 />
               </DataTooltip>
             </div>
+            <div
+              v-if="item.lossBars.length"
+              class="grid h-1 items-end gap-[1px] opacity-80"
+              :style="{ gridTemplateColumns: `repeat(${item.lossBars.length}, minmax(0, 1fr))` }"
+            >
+              <DataTooltip
+                v-for="bar in item.lossBars"
+                :key="bar.key"
+                :content="bar.tooltip"
+                placement="top"
+                as="span"
+                class="h-full w-full"
+                content-class="whitespace-nowrap"
+              >
+                <span
+                  :aria-label="bar.tooltip"
+                  class="block h-full w-full rounded-[1px]"
+                  :class="bar.className"
+                />
+              </DataTooltip>
+            </div>
           </div>
         </div>
 

--- a/src/components/NodeCard.vue
+++ b/src/components/NodeCard.vue
@@ -457,25 +457,53 @@ const customTags = computed(() => parseTags(props.node.tags).flatMap(t => t.text
         </div>
 
         <!--
-          三网：按 ping 任务分项展示延迟，不做跨任务平均。
-          后台可能只配置了 1 个任务，也可能配置了多个（如电信/联通/移动三网测速）——
-          这里最多取前 3 项，单任务节点这里就是一个数字、没有分隔点，多任务节点用 · 分隔。
+          三网：按 ping 任务分项展示，不做跨任务平均。
+          后台配几个任务就显示几行（最多前 3 项），每行任务名 + 延迟 + 丢包 + 该任务自己的历史迷你条。
           只在存在任务级延迟数据时渲染，不占位、不影响其余节点的卡片高度。
         -->
         <div
           v-if="hasTaskLatencyItems"
-          class="flex items-center justify-between gap-2"
+          class="flex flex-col gap-1.5"
           :class="!props.node.online ? 'blur-xs opacity-50' : ''"
           @click.stop
         >
-          <span class="text-xs font-normal text-muted-foreground">三网</span>
-          <div class="flex items-center gap-1 font-mono text-xs font-medium">
-            <template v-for="(item, index) in taskLatencyItems" :key="item.key">
-              <span v-if="index > 0" class="text-muted-foreground/50">·</span>
-              <DataTooltip :content="item.tooltip" placement="top" as="span" content-class="whitespace-nowrap">
-                <span :class="latencyTextClass(item.valueText)">{{ item.valueText }}</span>
+          <div
+            v-for="item in taskLatencyItems"
+            :key="item.key"
+            class="flex flex-col gap-[1px]"
+          >
+            <div class="flex items-center justify-between gap-2">
+              <span class="truncate text-xs font-normal text-muted-foreground">{{ item.name }}</span>
+              <span class="flex shrink-0 items-center gap-1.5 font-mono text-xs font-medium">
+                <DataTooltip :content="item.tooltip" placement="top" as="span" content-class="whitespace-nowrap">
+                  <span :class="latencyTextClass(item.valueText)">{{ item.valueText }}</span>
+                </DataTooltip>
+                <DataTooltip :content="item.lossTooltip" placement="top" as="span" content-class="whitespace-nowrap">
+                  <span :class="lossTextClass(item.lossText)">{{ item.lossText }}</span>
+                </DataTooltip>
+              </span>
+            </div>
+            <div
+              v-if="item.historyBars.length"
+              class="grid h-1 items-end gap-[1px] opacity-80"
+              :style="{ gridTemplateColumns: `repeat(${item.historyBars.length}, minmax(0, 1fr))` }"
+            >
+              <DataTooltip
+                v-for="bar in item.historyBars"
+                :key="bar.key"
+                :content="bar.tooltip"
+                placement="top"
+                as="span"
+                class="h-full w-full"
+                content-class="whitespace-nowrap"
+              >
+                <span
+                  :aria-label="bar.tooltip"
+                  class="block h-full w-full rounded-[1px]"
+                  :class="bar.className"
+                />
               </DataTooltip>
-            </template>
+            </div>
           </div>
         </div>
 

--- a/src/components/NodeCard.vue
+++ b/src/components/NodeCard.vue
@@ -504,27 +504,6 @@ const customTags = computed(() => parseTags(props.node.tags).flatMap(t => t.text
                 />
               </DataTooltip>
             </div>
-            <div
-              v-if="item.lossBars.length"
-              class="grid h-1 items-end gap-[1px] opacity-80"
-              :style="{ gridTemplateColumns: `repeat(${item.lossBars.length}, minmax(0, 1fr))` }"
-            >
-              <DataTooltip
-                v-for="bar in item.lossBars"
-                :key="bar.key"
-                :content="bar.tooltip"
-                placement="top"
-                as="span"
-                class="h-full w-full"
-                content-class="whitespace-nowrap"
-              >
-                <span
-                  :aria-label="bar.tooltip"
-                  class="block h-full w-full rounded-[1px]"
-                  :class="bar.className"
-                />
-              </DataTooltip>
-            </div>
           </div>
         </div>
 

--- a/src/composables/useNodePingDisplay.ts
+++ b/src/composables/useNodePingDisplay.ts
@@ -24,7 +24,6 @@ export interface NodePingTaskLatencyItem {
   lossText: string
   lossTooltip: string
   historyBars: NodePingBar[]
-  lossBars: NodePingBar[]
 }
 
 const TASK_LATENCY_DISPLAY_LIMIT = 3
@@ -246,15 +245,6 @@ export function useNodePingDisplay(
             ? `${formatDateTime(point.time, 'HH:mm:ss')}\n无采样数据`
             : `${formatDateTime(point.time, 'HH:mm:ss')}\n${Math.round(point.latency)} ms`,
         }))
-        // 图二每家运营商下面有两排：延迟一排、丢包一排。这里第二排直接复用该任务自己的
-        // 分桶丢包（与延迟同一批桶），色阶走自带 getLossToneClass，不另起一套。
-        const lossBars: NodePingBar[] = (task.history ?? []).map((point, index) => ({
-          key: `${task.taskId}-loss-${point.time}-${index}`,
-          className: point.loss === null ? 'bg-muted-foreground/15' : getLossToneClass(point.loss),
-          tooltip: point.loss === null
-            ? `${formatDateTime(point.time, 'HH:mm:ss')}\n无采样数据`
-            : `${formatDateTime(point.time, 'HH:mm:ss')}\n${point.loss.toFixed(1)}%`,
-        }))
         return {
           key: task.taskId,
           name: label,
@@ -263,7 +253,6 @@ export function useNodePingDisplay(
           lossText,
           lossTooltip: `${label} 丢包 ${lossText}`,
           historyBars,
-          lossBars,
         }
       })
   })

--- a/src/composables/useNodePingDisplay.ts
+++ b/src/composables/useNodePingDisplay.ts
@@ -18,8 +18,12 @@ export interface NodePingBar {
 // UI 侧固定只取前 N_TASK_LATENCY_ITEMS 项，其余的本阶段不处理。
 export interface NodePingTaskLatencyItem {
   key: string
+  name: string
   valueText: string
   tooltip: string
+  lossText: string
+  lossTooltip: string
+  historyBars: NodePingBar[]
 }
 
 const TASK_LATENCY_DISPLAY_LIMIT = 3
@@ -58,6 +62,19 @@ function getLossToneClass(loss: number): string {
   return 'bg-signal-5 ping-signal-pattern-4'
 }
 
+// 迷你条只用实心色阶，不带斜纹：h-1 高度下斜纹就是脏点，与延迟/丢包大块的实心观感对齐。
+function getLatencySolidClass(latency: number): string {
+  if (latency <= 60)
+    return 'bg-signal-1'
+  if (latency <= 100)
+    return 'bg-signal-2'
+  if (latency <= 160)
+    return 'bg-signal-3'
+  if (latency <= 200)
+    return 'bg-signal-4'
+  return 'bg-signal-5'
+}
+
 export function useNodePingDisplay(
   uuid: MaybeRefOrGetter<string>,
   options: UseNodePingDisplayOptions = {},
@@ -85,26 +102,34 @@ export function useNodePingDisplay(
     maxCount: PING_SUMMARY_MAX_COUNT,
   })
 
+  // 自带的唯一一套延迟色块构造：聚合大块和分任务迷你条都走这里，
+  // 不另起一套色阶/tooltip，避免两处展示语义分叉。
+  function toLatencyHistoryBar(time: string, latency: number | null, key: string): NodePingBar {
+    return {
+      key,
+      className: latency === null ? 'bg-muted-foreground/15' : getLatencyToneClass(latency),
+      tooltip: latency === null
+        ? `${formatDateTime(time, 'HH:mm:ss')}\n无采样数据`
+        : `${formatDateTime(time, 'HH:mm:ss')}\n${Math.round(latency)} ms`,
+    }
+  }
+
   function buildPingBars(metric: NodePingMetric): NodePingBar[] {
     const points = pingStats.history.value
     if (!points.length)
       return []
 
     return points.map((point, index) => {
-      const value = point[metric]
+      if (metric === 'latency')
+        return toLatencyHistoryBar(point.time, point.latency, `${point.time}-${index}`)
 
+      const value = point[metric]
       return {
         key: `${point.time}-${index}`,
-        className: value === null
-          ? 'bg-muted-foreground/15'
-          : metric === 'latency'
-            ? getLatencyToneClass(value)
-            : getLossToneClass(value),
+        className: value === null ? 'bg-muted-foreground/15' : getLossToneClass(value),
         tooltip: value === null
           ? `${formatDateTime(point.time, 'HH:mm:ss')}\n无采样数据`
-          : metric === 'latency'
-            ? `${formatDateTime(point.time, 'HH:mm:ss')}\n${Math.round(value)} ms`
-            : `${formatDateTime(point.time, 'HH:mm:ss')}\n${value.toFixed(1)}%`,
+          : `${formatDateTime(point.time, 'HH:mm:ss')}\n${value.toFixed(1)}%`,
       }
     })
   }
@@ -204,18 +229,30 @@ export function useNodePingDisplay(
   })
 
   // 只要该节点配置了 ping 任务（不管 1 个、2 个还是 3 个以上），就取前
-  // TASK_LATENCY_DISPLAY_LIMIT 项渲染「三网」行；单任务节点这里就是一个数字，
-  // 不带分隔符——由使用方（模板）按数组长度自然渲染，这里不做数量上的特殊分支。
+  // TASK_LATENCY_DISPLAY_LIMIT 项渲染「三网」行；每项自带该任务自己的延迟历史迷你条
+  // 和丢包标量，不做跨任务平均。单任务节点这里就是一行，不做数量上的特殊分支。
   const taskLatencyItemsRaw = computed<NodePingTaskLatencyItem[]>(() => {
     return pingStats.taskLatencies.value
       .slice(0, TASK_LATENCY_DISPLAY_LIMIT)
       .map((task) => {
         const valueText = task.latency === null ? '--' : `${Math.round(task.latency)}ms`
         const label = task.name?.trim() || `任务 ${task.taskId}`
+        const lossText = task.loss === null || task.loss === undefined ? '--' : `${task.loss.toFixed(1)}%`
+        const historyBars: NodePingBar[] = (task.history ?? []).map((point, index) => ({
+          key: `${task.taskId}-${point.time}-${index}`,
+          className: point.latency === null ? 'bg-muted-foreground/15' : getLatencySolidClass(point.latency),
+          tooltip: point.latency === null
+            ? `${formatDateTime(point.time, 'HH:mm:ss')}\n无采样数据`
+            : `${formatDateTime(point.time, 'HH:mm:ss')}\n${Math.round(point.latency)} ms`,
+        }))
         return {
           key: task.taskId,
+          name: label,
           valueText,
-          tooltip: `${label} ${valueText}`,
+          tooltip: `${label} ${valueText} · 丢包 ${lossText}`,
+          lossText,
+          lossTooltip: `${label} 丢包 ${lossText}`,
+          historyBars,
         }
       })
   })

--- a/src/composables/useNodePingDisplay.ts
+++ b/src/composables/useNodePingDisplay.ts
@@ -24,6 +24,7 @@ export interface NodePingTaskLatencyItem {
   lossText: string
   lossTooltip: string
   historyBars: NodePingBar[]
+  lossBars: NodePingBar[]
 }
 
 const TASK_LATENCY_DISPLAY_LIMIT = 3
@@ -245,6 +246,15 @@ export function useNodePingDisplay(
             ? `${formatDateTime(point.time, 'HH:mm:ss')}\n无采样数据`
             : `${formatDateTime(point.time, 'HH:mm:ss')}\n${Math.round(point.latency)} ms`,
         }))
+        // 图二每家运营商下面有两排：延迟一排、丢包一排。这里第二排直接复用该任务自己的
+        // 分桶丢包（与延迟同一批桶），色阶走自带 getLossToneClass，不另起一套。
+        const lossBars: NodePingBar[] = (task.history ?? []).map((point, index) => ({
+          key: `${task.taskId}-loss-${point.time}-${index}`,
+          className: point.loss === null ? 'bg-muted-foreground/15' : getLossToneClass(point.loss),
+          tooltip: point.loss === null
+            ? `${formatDateTime(point.time, 'HH:mm:ss')}\n无采样数据`
+            : `${formatDateTime(point.time, 'HH:mm:ss')}\n${point.loss.toFixed(1)}%`,
+        }))
         return {
           key: task.taskId,
           name: label,
@@ -253,6 +263,7 @@ export function useNodePingDisplay(
           lossText,
           lossTooltip: `${label} 丢包 ${lossText}`,
           historyBars,
+          lossBars,
         }
       })
   })

--- a/src/composables/useNodePingStats.ts
+++ b/src/composables/useNodePingStats.ts
@@ -21,6 +21,10 @@ export interface NodePingTaskLatency {
   name?: string
   // 该任务当前没有任何有效样本时为 null，展示层应显示为占位符（如 --），而不是 0ms。
   latency: number | null
+  // 该任务的丢包率（%），无有效样本时为 null，展示层显示占位符。
+  loss: number | null
+  // 该任务各自的延迟历史（只取延迟部分画迷你条），不做跨任务平均。
+  history: NodePingHistoryPoint[]
 }
 
 export interface NodePingStatsState {
@@ -69,8 +73,8 @@ interface SharedPingRecordsEntry {
 }
 
 const HISTORY_BUCKET_COUNT = 20
-// v9：NodePingStatsState 新增 taskLatencies 字段，历史缓存条目结构不再匹配，需要整体失效重取。
-const CACHE_VERSION = 9
+// v10：NodePingStatsState.taskLatencies 新增 loss + history 字段，历史缓存条目结构不再匹配，需要整体失效重取。
+const CACHE_VERSION = 10
 const CACHE_KEY_PREFIX = 'komari-theme-emerald:node-ping-stats'
 const FULL_LOSS_EPSILON = 1e-6
 const PING_RECORD_REFRESH_INTERVAL_MS = 60_000
@@ -164,7 +168,9 @@ function isValidTaskLatency(value: unknown): value is NodePingTaskLatency {
   const item = value as Record<string, unknown>
   return typeof item.taskId === 'string'
     && (item.latency === null || typeof item.latency === 'number')
+    && (item.loss === undefined || item.loss === null || typeof item.loss === 'number')
     && (item.name === undefined || typeof item.name === 'string')
+    && (item.history === undefined || (Array.isArray(item.history) && (item.history as unknown[]).every(isValidHistoryPoint)))
 }
 
 function isValidStatsState(value: unknown): value is NodePingStatsState {
@@ -587,17 +593,27 @@ function buildStats(records: PingRecord[], metricStats?: PingMetricTaskStats[], 
 
     const avgLoss = weightedAverage(lossValues)
 
-    // 按任务保留各自的延迟数值（不做跨任务平均），供首页卡片「三网」行分项展示。
+    // 按任务保留各自的延迟/丢包/历史（不做跨任务平均），供首页卡片「三网」行分项展示。
     // 顺序沿用 statsWithSamples 的原始顺序（即后端 stats 接口返回的任务顺序，近似任务配置顺序）。
-    const taskLatencies: NodePingTaskLatency[] = statsWithSamples.map(stat => ({
-      taskId: stat.task_id,
-      name: stat.name,
-      latency: stat.valid > 0 && isFiniteNumber(stat.avg)
-        ? stat.avg
-        : isFiniteNumber(stat.latest)
-          ? stat.latest
-          : null,
-    }))
+    // 历史按该任务自己的采样点单独分桶，只取延迟部分画迷你条；metric 的丢包明细是聚合的，
+    // 分任务丢包只给标量（stat.loss），不伪造分任务丢包历史。
+    const taskLatencies: NodePingTaskLatency[] = statsWithSamples.map((stat) => {
+      const numericTaskId = normalizeTaskId(stat.task_id)
+      const taskRecords = Number.isFinite(numericTaskId)
+        ? records.filter(record => record.task_id === numericTaskId)
+        : []
+      return {
+        taskId: stat.task_id,
+        name: stat.name,
+        latency: stat.valid > 0 && isFiniteNumber(stat.avg)
+          ? stat.avg
+          : isFiniteNumber(stat.latest)
+            ? stat.latest
+            : null,
+        loss: !stat.loss_approximate && isFiniteNumber(stat.loss) ? stat.loss : null,
+        history: buildPingHistory(taskRecords),
+      }
+    })
 
     return {
       avgLatency: latencyValues.length ? weightedAverage(latencyValues) : average(latestLatencyValues),
@@ -636,16 +652,18 @@ function buildStats(records: PingRecord[], metricStats?: PingMetricTaskStats[], 
       .map(record => record.value)
       .filter(value => value >= 0)
 
-    taskLossValues.push((recordsByTask.length - validValues.length) / recordsByTask.length * 100)
+    const taskLoss = (recordsByTask.length - validValues.length) / recordsByTask.length * 100
+    taskLossValues.push(taskLoss)
+    const taskHistory = buildPingHistory(recordsByTask)
 
     if (!validValues.length) {
-      taskLatencies.push({ taskId: String(taskId), latency: null })
+      taskLatencies.push({ taskId: String(taskId), latency: null, loss: taskLoss, history: taskHistory })
       continue
     }
 
     const taskAvgLatency = average(validValues)
     latencyValues.push(taskAvgLatency)
-    taskLatencies.push({ taskId: String(taskId), latency: taskAvgLatency })
+    taskLatencies.push({ taskId: String(taskId), latency: taskAvgLatency, loss: taskLoss, history: taskHistory })
 
     if (validValues.length > 1) {
       const p50 = getPercentile(validValues, 0.5)


### PR DESCRIPTION
首页卡片三网行从单行·分隔改成按后台任务纵向三行直显：任务名 + 延迟 + 丢包 + 各自历史迷你条（实心色阶，与聚合大块同一套构造），不写死任务名，最多前3项。数据层 taskLatencies 补 loss + per-task history，CACHE_VERSION 9→10。komari-theme.json 0.6.6→0.6.7，lint+build通过，本地 Komari 1.4.3 + agent 真机验证截图见附件产物。